### PR TITLE
Add TypeScript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'hapi-request-user';


### PR DESCRIPTION
I wanted to use this package in Hapi/TypeScript project so I had to add this file in `node_modules/hapi-request-user` to work properly.